### PR TITLE
Change Navmesh runtime generation to dynamic (Fix Issue #90)

### DIFF
--- a/Config/DefaultEngine.ini
+++ b/Config/DefaultEngine.ini
@@ -33,3 +33,5 @@ DirtyAreasUpdateFreq=60.000000
 
 [/Script/NavigationSystem.RecastNavMesh]
 CellSize=5.000000
+RuntimeGeneration=Dynamic
+


### PR DESCRIPTION
Fix issue #90 by having AI recalculate navmesh, thus not walking off the arena.